### PR TITLE
Fix: replaced absolute paths in main.py and searchbin.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ if path not in sys.path:
     sys.path.append(path)
 from minidump.minidumpfile import *
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
 # Dump the process with procdump.exe -ma <PID>
 # Pattern to search for (part of the key_data_s structure, in particular alg_id, flags and key_size):
 # 106600000100000020000000
@@ -104,11 +106,11 @@ def get_keys_from_offsets(dump, offsets):
 
 
 def search_pattern(dump, pattern):
-    # TODO: Change these paths
-    subprocess.run(["C:/Users/w/PycharmProjects/AvaddonDecryptor/venv/Scripts/python.exe",
-                    "C:/Users/w/PycharmProjects/AvaddonDecryptor/searchbin.py", "-p", str(pattern),
+    # Fixed TODO, paths relative to main file
+    subprocess.run([f"python.exe",  # remember to activate venv
+                    f"{script_dir}/searchbin.py", "-p", str(pattern),
                     os.path.abspath(dump)], stdout=subprocess.PIPE)
-    with open("C:/Users/w/PycharmProjects/AvaddonDecryptor/testing.matches", "r") as f:
+    with open(f"{script_dir}/testing.matches", "r") as f:
         offsets = json.load(f)
     return offsets['matches']
 

--- a/searchbin.py
+++ b/searchbin.py
@@ -29,6 +29,9 @@ import re
 import signal
 import sys
 import json
+import os
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Global variables.
 CONTACT = ("sepero 111 @ gmx . com\n"
@@ -404,7 +407,7 @@ def main():
     args = get_args()  # Get commandline arguments.
     args = verify_args(args)  # Check arguments for sanity, and edit them a bit.
     global report_json
-    report_json = report_json_class("C:/Users/w/PycharmProjects/AvaddonDecryptor/testing.matches")
+    report_json = report_json_class(f"{script_dir}/testing.matches")
     if args.fsearch:  # If filenames were given on the commandline, process them.
         while args.fsearch:  # List of files to search inside.
             try:  # Open a filehandler for the filename.


### PR DESCRIPTION
## Problem to fix
Both scripts `main.py` and `searchbin.py` were using an absolute path for a JSON report, Python executable and to invoke other scripts of the repository, which made the execution fail if the repo did not exist in that specific folder.

## Proposed fix
The proposed fix patches the following:
* Acquires the current location of the script through `os` (lib) and `__file__` at script scope
* Replaces the absolute paths with the aforesaid value
* Assumes that the path for Python is properly configured (or that the venv has been manually activated) and invokes it directly (`pyhton.exe`) 